### PR TITLE
Fix SonarCloud CI configuration

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_branch }}
           fetch-depth: 0
 
       - name: Download test artifacts
@@ -33,7 +35,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        with:
-          args: >
-            -Dsonar.organization=${{ secrets.SONAR_ORGANIZATION }}
-            -Dsonar.projectKey=${{ secrets.SONAR_PROJECT_KEY }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,7 @@
+sonar.projectKey=catch-oss_abc-silverstripe-social
+sonar.organization=catch-design
+sonar.sources=code
+sonar.sourceEncoding=UTF-8
+sonar.php.coverage.reportPaths=coverage/php/coverage.xml
+sonar.php.tests.reportPath=coverage/php/junit.xml
+sonar.exclusions=vendor/**,tests/**


### PR DESCRIPTION
## Summary
- Remove `args` block from sonar.yml that relied on secrets for `sonar.organization` and `sonar.projectKey`
- Add `sonar-project.properties` with project key, organization, source dirs, and coverage paths
- Add `repository` and `ref` parameters to checkout step so workflow_run triggers check out the correct commit

## Test plan
- [ ] Verify SonarCloud workflow triggers after a test run on release/6
- [ ] Confirm SonarCloud scan picks up project config from sonar-project.properties
- [ ] Check coverage/junit reports are correctly referenced

🤖 Generated with [Claude Code](https://claude.com/claude-code)