### PR TITLE
Update SonarCloud workflow and config

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -6,9 +6,27 @@ on:
     types: [completed]
 
 jobs:
-  sonarqube:
-    name: SonarQube
+  sonarcloud:
+    name: SonarCloud
     runs-on: ubuntu-latest
+
+    env:
+      SONAR_PROJECT_KEY: catch-design_catch-oss-abc-silverstripe-social
+
+    outputs:
+      alert_status: ${{ steps.sonarqube-report.outputs.alert_status }}
+      bugs: ${{ steps.sonarqube-report.outputs.bugs }}
+      code_smells: ${{ steps.sonarqube-report.outputs.code_smells }}
+      coverage: ${{ steps.sonarqube-report.outputs.coverage }}
+      duplicated_lines_density: ${{ steps.sonarqube-report.outputs.duplicated_lines_density }}
+      ncloc: ${{ steps.sonarqube-report.outputs.ncloc }}
+      reliability_rating: ${{ steps.sonarqube-report.outputs.reliability_rating }}
+      security_rating: ${{ steps.sonarqube-report.outputs.security_rating }}
+      sqale_index: ${{ steps.sonarqube-report.outputs.sqale_index }}
+      sqale_rating: ${{ steps.sonarqube-report.outputs.sqale_rating }}
+      vulnerabilities: ${{ steps.sonarqube-report.outputs.vulnerabilities }}
+      git_ref: ${{ steps.sonarqube-report.outputs.git_ref }}
+
     permissions:
       actions: read
       contents: read
@@ -17,6 +35,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
       - name: Download test artifacts
@@ -28,12 +48,94 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: SonarQube Scan
+      - name: Resolve SonarCloud scan parameters
+        id: sonar-params
+        env:
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          BASE_BRANCH: ${{ github.event.workflow_run.pull_requests[0].base.ref }}
+        run: |
+          if [ -n "$PR_NUMBER" ]; then
+            echo "args=-Dsonar.pullrequest.key=$PR_NUMBER -Dsonar.pullrequest.branch=$HEAD_BRANCH -Dsonar.pullrequest.base=$BASE_BRANCH" >> "$GITHUB_OUTPUT"
+            echo "ref=pullRequest=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          else
+            ENCODED_REF=$(printf '%s' "$HEAD_BRANCH" | jq -sRr @uri)
+            echo "args=-Dsonar.branch.name=$HEAD_BRANCH" >> "$GITHUB_OUTPUT"
+            echo "ref=branch=$ENCODED_REF" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: SonarCloud Scan
+        id: sonarqube-scan
         uses: SonarSource/sonarqube-scan-action@master
+        with:
+          args: ${{ steps.sonar-params.outputs.args }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+      - name: Fail job if Quality Gate fails
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_REF: ${{ steps.sonar-params.outputs.ref }}
+        run: |
+          URL="https://sonarcloud.io/api/measures/component?metricKeys=alert_status&component=$SONAR_PROJECT_KEY&$SONAR_REF"
+          for attempt in 1 2 3 4 5; do
+            HTTP_CODE=$(curl --silent --output /tmp/sonar_response.json --write-out '%{http_code}' \
+              -H "Authorization: Bearer $SONAR_TOKEN" "$URL")
+            if [ "$HTTP_CODE" = "200" ]; then
+              break
+            fi
+            echo "Attempt $attempt: HTTP $HTTP_CODE — waiting for SonarCloud to process results..."
+            cat /tmp/sonar_response.json
+            echo ""
+            sleep 15
+          done
+
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "Failed to fetch quality gate after 5 attempts (HTTP $HTTP_CODE)"
+            cat /tmp/sonar_response.json
+            exit 1
+          fi
+
+          STATUS=$(jq -r '.component.measures[0].value // "ERROR"' /tmp/sonar_response.json)
+          echo "Quality Gate: ${STATUS}"
+          [ "$STATUS" = "OK" ] || { echo "Quality Gate failed with status: $STATUS"; exit 1; }
+
+      - name: Output SonarCloud metrics
+        id: sonarqube-report
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_REF: ${{ steps.sonar-params.outputs.ref }}
+        run: |
+          URL="https://sonarcloud.io/api/measures/component?metricKeys=alert_status%2Cbugs%2Ccode_smells%2Ccoverage%2Cduplicated_lines_density%2Cncloc%2Creliability_rating%2Csecurity_rating%2Csqale_index%2Csqale_rating%2Cvulnerabilities&component=$SONAR_PROJECT_KEY&$SONAR_REF"
+          DATA=$(curl --fail --silent -H "Authorization: Bearer $SONAR_TOKEN" "$URL")
+
+          for metric in alert_status bugs code_smells coverage duplicated_lines_density ncloc reliability_rating security_rating sqale_index sqale_rating vulnerabilities; do
+            value=$(echo "$DATA" | jq -r --arg m "$metric" '.component.measures[] | select(.metric == $m) | .value')
+            echo "${metric}=${value}" >> "$GITHUB_OUTPUT"
+          done
+          echo "git_ref=$SONAR_REF" >> "$GITHUB_OUTPUT"
+
+      - name: Comment PR
+        uses: thollander/actions-comment-pull-request@v3
+        if: github.event.workflow_run.pull_requests[0].number != ''
         with:
-          args: >
-            -Dsonar.organization=${{ secrets.SONAR_ORGANIZATION }}
-            -Dsonar.projectKey=${{ secrets.SONAR_PROJECT_KEY }}
+          pr-number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          message: |
+            ## SonarCloud Analysis Results
+            ### Quality Gate Status: ${{ steps.sonarqube-report.outputs.alert_status }}
+            ### Metrics
+            - **Bugs**: ${{ steps.sonarqube-report.outputs.bugs }}
+            - **Code Smells**: ${{ steps.sonarqube-report.outputs.code_smells }}
+            - **Coverage**: ${{ steps.sonarqube-report.outputs.coverage }}
+            - **Duplicated Lines Density**: ${{ steps.sonarqube-report.outputs.duplicated_lines_density }}
+            - **Lines of Code (ncloc)**: ${{ steps.sonarqube-report.outputs.ncloc }}
+            - **Reliability Rating**: ${{ steps.sonarqube-report.outputs.reliability_rating }}
+            - **Security Rating**: ${{ steps.sonarqube-report.outputs.security_rating }}
+            - **Technical Debt (sqale index)**: ${{ steps.sonarqube-report.outputs.sqale_index }}
+            - **Maintainability Rating**: ${{ steps.sonarqube-report.outputs.sqale_rating }}
+            - **Vulnerabilities**: ${{ steps.sonarqube-report.outputs.vulnerabilities }}
+            ### More details
+            - [SonarCloud dashboard](https://sonarcloud.io/dashboard?id=catch-design_catch-oss-abc-silverstripe-social&${{ steps.sonarqube-report.outputs.git_ref }})
+            - [View the full report](https://sonarcloud.io/project/issues?id=catch-design_catch-oss-abc-silverstripe-social&${{ steps.sonarqube-report.outputs.git_ref }}&resolved=false)
+            - [View the Quality Gate](https://sonarcloud.io/summary/new_code?id=catch-design_catch-oss-abc-silverstripe-social&${{ steps.sonarqube-report.outputs.git_ref }})

--- a/README.md
+++ b/README.md
@@ -1,4 +1,21 @@
-# what can this thing do
+# abc-silverstripe-social
+
+<!-- PROJECT SHIELDS -->
+[![SonarCloud](https://github.com/catch-oss/abc-silverstripe-social/actions/workflows/sonar.yml/badge.svg)](https://github.com/catch-oss/abc-silverstripe-social/actions/workflows/sonar.yml)
+[![Test](https://github.com/catch-oss/abc-silverstripe-social/actions/workflows/test.yml/badge.svg)](https://github.com/catch-oss/abc-silverstripe-social/actions/workflows/test.yml)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=catch-design_catch-oss-abc-silverstripe-social&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=catch-design_catch-oss-abc-silverstripe-social)
+[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=catch-design_catch-oss-abc-silverstripe-social&metric=bugs)](https://sonarcloud.io/component_measures?id=catch-design_catch-oss-abc-silverstripe-social)
+[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=catch-design_catch-oss-abc-silverstripe-social&metric=code_smells)](https://sonarcloud.io/component_measures?id=catch-design_catch-oss-abc-silverstripe-social)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=catch-design_catch-oss-abc-silverstripe-social&metric=coverage)](https://sonarcloud.io/component_measures?id=catch-design_catch-oss-abc-silverstripe-social)
+[![Duplicated Lines Density](https://sonarcloud.io/api/project_badges/measure?project=catch-design_catch-oss-abc-silverstripe-social&metric=duplicated_lines_density)](https://sonarcloud.io/component_measures?id=catch-design_catch-oss-abc-silverstripe-social)
+[![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=catch-design_catch-oss-abc-silverstripe-social&metric=ncloc)](https://sonarcloud.io/component_measures?id=catch-design_catch-oss-abc-silverstripe-social)
+[![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=catch-design_catch-oss-abc-silverstripe-social&metric=reliability_rating)](https://sonarcloud.io/component_measures?id=catch-design_catch-oss-abc-silverstripe-social)
+[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=catch-design_catch-oss-abc-silverstripe-social&metric=security_rating)](https://sonarcloud.io/component_measures?id=catch-design_catch-oss-abc-silverstripe-social)
+[![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=catch-design_catch-oss-abc-silverstripe-social&metric=sqale_index)](https://sonarcloud.io/component_measures?id=catch-design_catch-oss-abc-silverstripe-social)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=catch-design_catch-oss-abc-silverstripe-social&metric=sqale_rating)](https://sonarcloud.io/component_measures?id=catch-design_catch-oss-abc-silverstripe-social)
+[![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=catch-design_catch-oss-abc-silverstripe-social&metric=vulnerabilities)](https://sonarcloud.io/component_measures?id=catch-design_catch-oss-abc-silverstripe-social)
+
+Library that adds some social media functionality to Silverstripe:
 
 - Downloads your facebook, instagram or twitter feed and puts it somewhere of your choosing in your site tree
 - Shares the current page to facebook or twitter when you save it (WIP).
@@ -32,8 +49,7 @@ Include the `Meta` partial in your page template e.g.:
 - config.yml
 
 
-License
--------
+## License
 
 Copyright (c) 2015, azt3k
 All rights reserved.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,14 @@
+sonar.projectKey=catch-design_catch-oss-abc-silverstripe-social
+sonar.organization=catch-design
+
+# Source and test paths
+sonar.sources=code
+sonar.tests=tests
+sonar.sourceEncoding=UTF-8
+
+# PHP coverage - these paths match the test.yml output
+sonar.php.coverage.reportPaths=coverage/php/coverage.xml
+sonar.php.tests.reportPath=coverage/php/junit.xml
+
+# Exclusions
+sonar.exclusions=vendor/**,tests/**


### PR DESCRIPTION
## Summary

Updates CI workflows for the SS6 migration:

- **sonar.yml**: Rewritten with PR context resolution, quality gate check (5-attempt retry), metrics output, and PR commenting. Reads org/projectKey from `sonar-project.properties` instead of secrets
- **sonar-project.properties**: New file with project key, org, source/test paths, coverage paths
- **README.md**: Added CI and SonarCloud badges

### Secrets Required

Ensure these secrets are configured (org-level or repo-level):
- `ANTHROPIC_API_KEY` - for Claude PR review
- `SONAR_TOKEN` - for SonarCloud analysis

Note: `sonar.organization` and `sonar.projectKey` are read from `sonar-project.properties` — they do NOT need to be set as secrets.

---

Generated by SS6 Migration Toolkit