### PR TITLE
Harden sync tasks to be opt-in with env-level kill switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,73 @@ Page:
 
 Then run `dev/build` to apply the database changes.
 
+## Sync Tasks
+
+The module ships 4 cron tasks that pull social media feeds into your site tree. All sync tasks are **disabled by default** and require explicit opt-in at the environment level.
+
+### Available tasks
+
+| Command | Description |
+|---------|-------------|
+| `social:sync-facebook` | Pulls posts from a configured Facebook page |
+| `social:retry-sync-facebook-images` | Retries downloading images for recent Facebook posts that had no image on first sync |
+| `social:sync-twitter` | Pulls tweets from a configured Twitter account |
+| `social:sync-instagram` | Pulls posts from a configured Instagram account |
+
+### Enabling sync
+
+**1. Set the environment variable** (required — without this, all tasks exit immediately):
+
+```
+SS_SOCIAL_SYNC_ENABLED=1
+```
+
+Add this to your `.env` file or set it in your hosting environment.
+
+**2. Enable per-network in the CMS** (Settings > Social Media):
+
+- **Facebook:** Toggle `FacebookPullUpdates`
+- **Twitter:** Toggle `TwitterPullUpdates`
+- **Instagram:** Toggle `InstagramPullUpdates`
+
+Both the env var and the CMS toggle must be enabled for a given network's sync to run.
+
+### Running tasks
+
+**Via cron (recommended):** Set up an external cron job to run the Silverstripe cron task runner:
+
+```bash
+* * * * * cd /path/to/project && vendor/bin/sake cron-task
+```
+
+Each task has a schedule (e.g. every 5 minutes) that the cron runner respects.
+
+**Manually via CLI:**
+
+```bash
+vendor/bin/sake social:sync-facebook
+vendor/bin/sake social:sync-twitter
+vendor/bin/sake social:sync-instagram
+vendor/bin/sake social:retry-sync-facebook-images
+```
+
+### Overriding schedules
+
+The default schedules can be overridden via YAML config in your project:
+
+```yaml
+# app/_config/social-sync.yml
+---
+Name: project-social-sync
+After:
+  - '#abc-silverstripe-social-sync'
+---
+Azt3k\SS\Social\BuildTasks\SyncFacebook:
+  schedule: '*/10 * * * *'
+Azt3k\SS\Social\BuildTasks\SyncInstagram:
+  schedule: '0 * * * *'
+```
+
 ## Meta data
 
 Include the `Meta` partial in your page template:

--- a/_config/sync.yml
+++ b/_config/sync.yml
@@ -1,0 +1,11 @@
+---
+Name: abc-silverstripe-social-sync
+---
+Azt3k\SS\Social\BuildTasks\SyncFacebook:
+  schedule: '*/5 * * * *'
+Azt3k\SS\Social\BuildTasks\RetrySyncFacebookImages:
+  schedule: '*/15 * * * *'
+Azt3k\SS\Social\BuildTasks\SyncTwitter:
+  schedule: '*/5 * * * *'
+Azt3k\SS\Social\BuildTasks\SyncInstagram:
+  schedule: '*/5 * * * *'

--- a/src/BuildTasks/RetrySyncFacebookImages.php
+++ b/src/BuildTasks/RetrySyncFacebookImages.php
@@ -5,6 +5,7 @@ namespace Azt3k\SS\Social\BuildTasks;
 use JanuSoftware\Facebook\Facebook;
 use Azt3k\SS\Classes\DataObjectHelper;
 use Azt3k\SS\Social\SiteTree\FBUpdate;
+use SilverStripe\Core\Environment;
 use SilverStripe\CronTask\Interfaces\CronTask;
 use SilverStripe\PolyExecution\PolyCommand;
 use SilverStripe\PolyExecution\PolyOutput;
@@ -22,6 +23,8 @@ class RetrySyncFacebookImages extends PolyCommand implements CronTask
     protected static string $commandName = 'social:retry-sync-facebook-images';
     protected static string $description = 'Retries syncing Facebook images that were not immediately available';
 
+    private static string $schedule = '*/15 * * * *';
+
     protected static $conf_instance;
     protected $conf;
 
@@ -30,15 +33,9 @@ class RetrySyncFacebookImages extends PolyCommand implements CronTask
         return 'Retry Sync Facebook Images';
     }
 
-    public function __construct()
-    {
-        $this->conf = $this->getConf();
-        parent::__construct();
-    }
-
     public function getSchedule(): string
     {
-        return "*/15 * * * *";
+        return static::config()->get('schedule');
     }
 
     public function getConf(): mixed
@@ -52,7 +49,11 @@ class RetrySyncFacebookImages extends PolyCommand implements CronTask
      */
     public function process(): void
     {
-        if (!$this->conf) $this->__construct();
+        if (!Environment::getEnv('SS_SOCIAL_SYNC_ENABLED')) {
+            return;
+        }
+
+        $this->conf = $this->getConf();
         echo "\n\nSyncing\n\n";
 
         if (!$this->conf->FacebookPullUpdates) {
@@ -80,7 +81,12 @@ class RetrySyncFacebookImages extends PolyCommand implements CronTask
     public function run(InputInterface $input, PolyOutput $output): int
     {
 
-        if (!$this->conf) $this->__construct();
+        if (!Environment::getEnv('SS_SOCIAL_SYNC_ENABLED')) {
+            $output->writeln('Social sync disabled (SS_SOCIAL_SYNC_ENABLED is not set)');
+            return Command::SUCCESS;
+        }
+
+        $this->conf = $this->getConf();
 
         $output->writeln('');
         $output->writeln('Syncing');

--- a/src/BuildTasks/SyncFacebook.php
+++ b/src/BuildTasks/SyncFacebook.php
@@ -7,6 +7,7 @@ use Azt3k\SS\Social\Objects\SocialHelper;
 use Azt3k\SS\Classes\DataObjectHelper;
 use Azt3k\SS\Social\SiteTree\FBUpdate;
 use Azt3k\SS\Social\DataObjects\PublicationFBUpdate;
+use SilverStripe\Core\Environment;
 use SilverStripe\CronTask\Interfaces\CronTask;
 use SilverStripe\PolyExecution\PolyCommand;
 use SilverStripe\PolyExecution\PolyOutput;
@@ -25,6 +26,8 @@ class SyncFacebook extends PolyCommand implements CronTask
     protected static string $commandName = 'social:sync-facebook';
     protected static string $description = 'Syncs Facebook updates from a configured page';
 
+    private static string $schedule = '*/5 * * * *';
+
     protected static $conf_instance;
     protected static $facebook_instance;
     protected $conf;
@@ -37,18 +40,9 @@ class SyncFacebook extends PolyCommand implements CronTask
         return 'Sync Facebook';
     }
 
-    public function __construct()
-    {
-
-        $this->conf     = $this->getConf();
-        $this->facebook = $this->getFacebook();
-
-        parent::__construct();
-    }
-
     public function getSchedule(): string
     {
-        return "*/5 * * * *";
+        return static::config()->get('schedule');
     }
 
     public function getConf(): mixed
@@ -87,7 +81,11 @@ class SyncFacebook extends PolyCommand implements CronTask
      */
     public function process(): void
     {
-        if (!$this->conf || !$this->facebook) $this->__construct();
+        if (!Environment::getEnv('SS_SOCIAL_SYNC_ENABLED')) {
+            return;
+        }
+
+        $this->conf = $this->getConf();
 
         $eol = php_sapi_name() === 'cli' ? "\n" : '<br>';
 
@@ -100,13 +98,19 @@ class SyncFacebook extends PolyCommand implements CronTask
             return;
         }
 
+        $this->facebook = $this->getFacebook();
         $this->doSync(null);
     }
 
     public function run(InputInterface $input, PolyOutput $output): int
     {
 
-        if (!$this->conf || !$this->facebook) $this->__construct();
+        if (!Environment::getEnv('SS_SOCIAL_SYNC_ENABLED')) {
+            $output->writeln('Social sync disabled (SS_SOCIAL_SYNC_ENABLED is not set)');
+            return Command::SUCCESS;
+        }
+
+        $this->conf = $this->getConf();
 
         $output->writeln('');
         $output->writeln('Syncing...');
@@ -117,6 +121,7 @@ class SyncFacebook extends PolyCommand implements CronTask
             return Command::SUCCESS;
         }
 
+        $this->facebook = $this->getFacebook();
         $this->doSync($output);
 
         return Command::SUCCESS;

--- a/src/BuildTasks/SyncInstagram.php
+++ b/src/BuildTasks/SyncInstagram.php
@@ -6,6 +6,7 @@ use Azt3k\SS\Social\Clients\InstagramBasicDisplayClient;
 use Azt3k\SS\Social\SiteTree\InstagramUpdate;
 use Azt3k\SS\Social\DataObjects\PublicationInstagramUpdate;
 use Azt3k\SS\Social\Objects\SocialHelper;
+use SilverStripe\Core\Environment;
 use SilverStripe\CronTask\Interfaces\CronTask;
 use SilverStripe\PolyExecution\PolyCommand;
 use SilverStripe\PolyExecution\PolyOutput;
@@ -25,6 +26,8 @@ class SyncInstagram extends PolyCommand implements CronTask
     protected static string $commandName = 'social:sync-instagram';
     protected static string $description = 'Syncs Instagram updates from a configured account';
 
+    private static string $schedule = '*/5 * * * *';
+
     protected static $conf_instance;
     protected static $instagram_instance;
     protected $conf;
@@ -37,18 +40,9 @@ class SyncInstagram extends PolyCommand implements CronTask
         return 'Sync Instagram';
     }
 
-    public function __construct()
-    {
-
-        $this->conf = static::get_conf();
-        $this->instagram = static::get_instagram();
-
-        parent::__construct();
-    }
-
     public function getSchedule(): string
     {
-        return "*/5 * * * *";
+        return static::config()->get('schedule');
     }
 
     public static function get_conf(): mixed
@@ -76,7 +70,11 @@ class SyncInstagram extends PolyCommand implements CronTask
      */
     public function process(): void
     {
-        if (!$this->conf || !$this->instagram) $this->__construct();
+        if (!Environment::getEnv('SS_SOCIAL_SYNC_ENABLED')) {
+            return;
+        }
+
+        $this->conf = static::get_conf();
 
         $eol = php_sapi_name() === 'cli' ? "\n" : '<br>';
 
@@ -94,6 +92,7 @@ class SyncInstagram extends PolyCommand implements CronTask
             return;
         }
 
+        $this->instagram = static::get_instagram();
         $this->refreshAccessTokenIfNeeded();
         $this->doSync(null);
     }
@@ -101,7 +100,12 @@ class SyncInstagram extends PolyCommand implements CronTask
     public function run(InputInterface $input, PolyOutput $output): int
     {
 
-        if (!$this->conf || !$this->instagram) $this->__construct();
+        if (!Environment::getEnv('SS_SOCIAL_SYNC_ENABLED')) {
+            $output->writeln('Social sync disabled (SS_SOCIAL_SYNC_ENABLED is not set)');
+            return Command::SUCCESS;
+        }
+
+        $this->conf = static::get_conf();
 
         $output->writeln('');
         $output->writeln('Syncing...');
@@ -117,6 +121,7 @@ class SyncInstagram extends PolyCommand implements CronTask
             return Command::SUCCESS;
         }
 
+        $this->instagram = static::get_instagram();
         $this->refreshAccessTokenIfNeeded();
         $this->doSync($output);
 

--- a/src/BuildTasks/SyncInstagram.php
+++ b/src/BuildTasks/SyncInstagram.php
@@ -45,19 +45,20 @@ class SyncInstagram extends PolyCommand implements CronTask
         return static::config()->get('schedule');
     }
 
-    public static function get_conf(): mixed
+    public function getConf(): mixed
     {
         if (!static::$conf_instance) static::$conf_instance = SiteConfig::current_site_config();
         return static::$conf_instance;
     }
 
-    public static function get_instagram(): InstagramBasicDisplayClient
+    public function getInstagram(): InstagramBasicDisplayClient
     {
+        if (!$this->conf) $this->conf = $this->getConf();
+
         if (!static::$instagram_instance) {
-            $conf = static::get_conf();
             static::$instagram_instance = new InstagramBasicDisplayClient(
-                (string) $conf->InstagramApiKey,
-                (string) $conf->InstagramApiSecret,
+                (string) $this->conf->InstagramApiKey,
+                (string) $this->conf->InstagramApiSecret,
                 SocialHelper::php_self()
             );
         }
@@ -74,7 +75,7 @@ class SyncInstagram extends PolyCommand implements CronTask
             return;
         }
 
-        $this->conf = static::get_conf();
+        $this->conf = $this->getConf();
 
         $eol = php_sapi_name() === 'cli' ? "\n" : '<br>';
 
@@ -92,7 +93,7 @@ class SyncInstagram extends PolyCommand implements CronTask
             return;
         }
 
-        $this->instagram = static::get_instagram();
+        $this->instagram = $this->getInstagram();
         $this->refreshAccessTokenIfNeeded();
         $this->doSync(null);
     }
@@ -105,7 +106,7 @@ class SyncInstagram extends PolyCommand implements CronTask
             return Command::SUCCESS;
         }
 
-        $this->conf = static::get_conf();
+        $this->conf = $this->getConf();
 
         $output->writeln('');
         $output->writeln('Syncing...');
@@ -121,7 +122,7 @@ class SyncInstagram extends PolyCommand implements CronTask
             return Command::SUCCESS;
         }
 
-        $this->instagram = static::get_instagram();
+        $this->instagram = $this->getInstagram();
         $this->refreshAccessTokenIfNeeded();
         $this->doSync($output);
 

--- a/src/BuildTasks/SyncTwitter.php
+++ b/src/BuildTasks/SyncTwitter.php
@@ -2,6 +2,7 @@
 
 namespace Azt3k\SS\Social\BuildTasks;
 
+use SilverStripe\Core\Environment;
 use SilverStripe\PolyExecution\PolyCommand;
 use SilverStripe\PolyExecution\PolyOutput;
 use Symfony\Component\Console\Command\Command;
@@ -22,6 +23,8 @@ class SyncTwitter extends PolyCommand implements CronTask
     protected static string $commandName = 'social:sync-twitter';
     protected static string $description = 'Syncs Twitter updates from a configured account';
 
+    private static string $schedule = '*/5 * * * *';
+
     protected static $conf_instance;
     protected static $tmh_oauth_instance;
     protected $conf;
@@ -34,18 +37,9 @@ class SyncTwitter extends PolyCommand implements CronTask
         return 'Sync Twitter';
     }
 
-    public function __construct()
-    {
-
-        $this->conf        = $this->getConf();
-        $this->tmhOAuth = $this->getTmhOauth();
-
-        parent::__construct();
-    }
-
     public function getSchedule(): string
     {
-        return "*/5 * * * *";
+        return static::config()->get('schedule');
     }
 
     public function getConf(): mixed
@@ -76,7 +70,11 @@ class SyncTwitter extends PolyCommand implements CronTask
      */
     public function process(): void
     {
-        if (!$this->conf || !$this->tmhOAuth) $this->__construct();
+        if (!Environment::getEnv('SS_SOCIAL_SYNC_ENABLED')) {
+            return;
+        }
+
+        $this->conf = $this->getConf();
 
         $eol = php_sapi_name() === 'cli' ? "\n" : '<br>';
 
@@ -89,13 +87,19 @@ class SyncTwitter extends PolyCommand implements CronTask
             return;
         }
 
+        $this->tmhOAuth = $this->getTmhOauth();
         $this->doSync(null);
     }
 
     public function run(InputInterface $input, PolyOutput $output): int
     {
 
-        if (!$this->conf || !$this->tmhOAuth) $this->__construct();
+        if (!Environment::getEnv('SS_SOCIAL_SYNC_ENABLED')) {
+            $output->writeln('Social sync disabled (SS_SOCIAL_SYNC_ENABLED is not set)');
+            return Command::SUCCESS;
+        }
+
+        $this->conf = $this->getConf();
 
         $output->writeln('');
         $output->writeln('Syncing...');
@@ -106,6 +110,7 @@ class SyncTwitter extends PolyCommand implements CronTask
             return Command::SUCCESS;
         }
 
+        $this->tmhOAuth = $this->getTmhOauth();
         $this->doSync($output);
 
         return Command::SUCCESS;

--- a/tests/BuildTasks/SyncTasksTest.php
+++ b/tests/BuildTasks/SyncTasksTest.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace Azt3k\SS\Social\Tests\BuildTasks;
+
+use Azt3k\SS\Social\BuildTasks\RetrySyncFacebookImages;
+use Azt3k\SS\Social\BuildTasks\SyncFacebook;
+use Azt3k\SS\Social\BuildTasks\SyncInstagram;
+use Azt3k\SS\Social\BuildTasks\SyncTwitter;
+use SilverStripe\Core\Environment;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\PolyExecution\PolyOutput;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SyncTasksTest extends SapphireTest
+{
+    protected $usesDatabase = false;
+
+    /**
+     * Store the original env value so we can restore it after each test
+     */
+    private string|false|null $originalEnvValue;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->originalEnvValue = Environment::getEnv('SS_SOCIAL_SYNC_ENABLED');
+    }
+
+    protected function tearDown(): void
+    {
+        // Restore original env value
+        if ($this->originalEnvValue === false) {
+            Environment::setEnv('SS_SOCIAL_SYNC_ENABLED', '');
+        } else {
+            Environment::setEnv('SS_SOCIAL_SYNC_ENABLED', $this->originalEnvValue);
+        }
+        parent::tearDown();
+    }
+
+    // ── Environment guard tests (run()) ──
+
+    public function testSyncFacebookRunExitsWhenEnvDisabled(): void
+    {
+        Environment::setEnv('SS_SOCIAL_SYNC_ENABLED', '');
+        $task = new SyncFacebook();
+        $result = $this->executeRun($task);
+
+        $this->assertSame(Command::SUCCESS, $result['code']);
+        $this->assertStringContainsString('SS_SOCIAL_SYNC_ENABLED is not set', $result['output']);
+    }
+
+    public function testRetrySyncFacebookImagesRunExitsWhenEnvDisabled(): void
+    {
+        Environment::setEnv('SS_SOCIAL_SYNC_ENABLED', '');
+        $task = new RetrySyncFacebookImages();
+        $result = $this->executeRun($task);
+
+        $this->assertSame(Command::SUCCESS, $result['code']);
+        $this->assertStringContainsString('SS_SOCIAL_SYNC_ENABLED is not set', $result['output']);
+    }
+
+    public function testSyncTwitterRunExitsWhenEnvDisabled(): void
+    {
+        Environment::setEnv('SS_SOCIAL_SYNC_ENABLED', '');
+        $task = new SyncTwitter();
+        $result = $this->executeRun($task);
+
+        $this->assertSame(Command::SUCCESS, $result['code']);
+        $this->assertStringContainsString('SS_SOCIAL_SYNC_ENABLED is not set', $result['output']);
+    }
+
+    public function testSyncInstagramRunExitsWhenEnvDisabled(): void
+    {
+        Environment::setEnv('SS_SOCIAL_SYNC_ENABLED', '');
+        $task = new SyncInstagram();
+        $result = $this->executeRun($task);
+
+        $this->assertSame(Command::SUCCESS, $result['code']);
+        $this->assertStringContainsString('SS_SOCIAL_SYNC_ENABLED is not set', $result['output']);
+    }
+
+    // ── Environment guard tests (process()) ──
+
+    public function testSyncFacebookProcessExitsWhenEnvDisabled(): void
+    {
+        Environment::setEnv('SS_SOCIAL_SYNC_ENABLED', '');
+        $task = new SyncFacebook();
+
+        ob_start();
+        $task->process();
+        $output = ob_get_clean();
+
+        // Should produce no output — exits before any echo
+        $this->assertEmpty($output);
+    }
+
+    public function testRetrySyncFacebookImagesProcessExitsWhenEnvDisabled(): void
+    {
+        Environment::setEnv('SS_SOCIAL_SYNC_ENABLED', '');
+        $task = new RetrySyncFacebookImages();
+
+        ob_start();
+        $task->process();
+        $output = ob_get_clean();
+
+        $this->assertEmpty($output);
+    }
+
+    public function testSyncTwitterProcessExitsWhenEnvDisabled(): void
+    {
+        Environment::setEnv('SS_SOCIAL_SYNC_ENABLED', '');
+        $task = new SyncTwitter();
+
+        ob_start();
+        $task->process();
+        $output = ob_get_clean();
+
+        $this->assertEmpty($output);
+    }
+
+    public function testSyncInstagramProcessExitsWhenEnvDisabled(): void
+    {
+        Environment::setEnv('SS_SOCIAL_SYNC_ENABLED', '');
+        $task = new SyncInstagram();
+
+        ob_start();
+        $task->process();
+        $output = ob_get_clean();
+
+        $this->assertEmpty($output);
+    }
+
+    // ── Configurable schedule tests ──
+
+    public function testSyncFacebookDefaultSchedule(): void
+    {
+        $task = new SyncFacebook();
+        $this->assertSame('*/5 * * * *', $task->getSchedule());
+    }
+
+    public function testRetrySyncFacebookImagesDefaultSchedule(): void
+    {
+        $task = new RetrySyncFacebookImages();
+        $this->assertSame('*/15 * * * *', $task->getSchedule());
+    }
+
+    public function testSyncTwitterDefaultSchedule(): void
+    {
+        $task = new SyncTwitter();
+        $this->assertSame('*/5 * * * *', $task->getSchedule());
+    }
+
+    public function testSyncInstagramDefaultSchedule(): void
+    {
+        $task = new SyncInstagram();
+        $this->assertSame('*/5 * * * *', $task->getSchedule());
+    }
+
+    public function testScheduleIsConfigurable(): void
+    {
+        $customSchedule = '0 */2 * * *';
+        SyncFacebook::config()->set('schedule', $customSchedule);
+
+        $task = new SyncFacebook();
+        $this->assertSame($customSchedule, $task->getSchedule());
+    }
+
+    // ── CronTask interface ──
+
+    public function testAllTasksImplementCronTask(): void
+    {
+        $classes = [
+            SyncFacebook::class,
+            RetrySyncFacebookImages::class,
+            SyncTwitter::class,
+            SyncInstagram::class,
+        ];
+
+        foreach ($classes as $class) {
+            $this->assertTrue(
+                is_subclass_of($class, \SilverStripe\CronTask\Interfaces\CronTask::class),
+                "$class should implement CronTask"
+            );
+        }
+    }
+
+    // ── Helpers ──
+
+    private function executeRun(object $task): array
+    {
+        $input = new ArrayInput([]);
+        $buffered = new BufferedOutput();
+        $output = new PolyOutput(
+            PolyOutput::FORMAT_ANSI,
+            OutputInterface::VERBOSITY_NORMAL,
+            false,
+            $buffered
+        );
+
+        $code = $task->run($input, $output);
+
+        return [
+            'code' => $code,
+            'output' => $buffered->fetch(),
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

- Add `SS_SOCIAL_SYNC_ENABLED` env var as infrastructure-level kill switch — all 4 sync tasks exit immediately when not set (disabled by default)
- Make constructors lazy: remove eager SiteConfig/SDK initialization from `__construct()`, defer to `process()`/`run()` after guards pass — no Facebook SDK, tmhOAuth, or Instagram client instantiated when sync is disabled
- Add configurable schedules via `private static $schedule` config property with YAML defaults in `_config/sync.yml`
- Document sync tasks, env var, CMS toggles, and schedule overrides in README

## Test plan

- [ ] Verify each task exits early without `SS_SOCIAL_SYNC_ENABLED` set
- [ ] Verify each task proceeds to SiteConfig check with `SS_SOCIAL_SYNC_ENABLED=1`
- [ ] Verify `getSchedule()` returns YAML-configured value
- [ ] Verify schedule override works via project YAML config
- [ ] Existing tests pass (pre-existing failures unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)