### PR TITLE
Hide auto-scaffolded tracking fields when push is disabled

### DIFF
--- a/src/Extensions/SocialMediaPageExtension.php
+++ b/src/Extensions/SocialMediaPageExtension.php
@@ -114,8 +114,9 @@ class SocialMediaPageExtension extends Extension {
     // Other Methods
     // ------------------------------------------------------------------------------------------------
 
-    public function parseContent(string $content, ?int $words = null, ?string $allowedTags = '<br>'): string
+    public function parseContent(?string $content, ?int $words = null, ?string $allowedTags = '<br>'): string
     {
+        $content = $content ?? '';
         $br2nl = false;
         if (!$allowedTags || stripos('<br>',$allowedTags) === false) {
             $allowedTags.= '<br>';

--- a/src/Extensions/SocialMediaPageExtension.php
+++ b/src/Extensions/SocialMediaPageExtension.php
@@ -162,6 +162,17 @@ class SocialMediaPageExtension extends Extension {
         $fields->removeByName('ExtraMeta');
         $fields->removeByName('Metadata');
 
+        // Always remove auto-scaffolded copies of internal tracking fields.
+        // They have no editor UI on the Main tab — LastPostedToSocialMedia and
+        // ForceUpdateMode are conditionally re-added to Root.SocialMedia below
+        // when push is enabled; the publication ID fields stay hidden.
+        $fields->removeByName([
+            'LastPostedToSocialMedia',
+            'PublicationFBUpdateID',
+            'PublicationTweetID',
+            'ForceUpdateMode',
+        ]);
+
         // Push updates stuff
         $conf = SiteConfig::current_site_config();
         if ($conf->TwitterPushUpdates || $conf->FacebookPushUpdates) {


### PR DESCRIPTION
## Summary
- SS6 auto-scaffolds every `$db` field onto the page edit Main tab. `SocialMediaPageExtension`'s internal tracking columns (`LastPostedToSocialMedia`, `PublicationFBUpdateID`, `PublicationTweetID`, `ForceUpdateMode`) had no editor UI when push is disabled, so they cluttered Main on every page in projects opting in to this extension.
- `updateCMSFields` now defensively `removeByName`s these four fields at the start. The existing conditional that re-adds `LastPostedToSocialMedia` + `ForceUpdateMode` to `Root.SocialMedia` (when Twitter/Facebook push is enabled) is unchanged.
- Found while triaging a SS6 CMS regression on the IoD project after their YAML opt-in to this extension surfaced these fields where SS5 never had them.

## Test plan
- [ ] Apply this branch via composer alias on a SS6 project that opts in to `SocialMediaPageExtension` but does NOT have `TwitterPushUpdates` / `FacebookPushUpdates` configured. Confirm the four tracking fields are gone from the page edit Main tab.
- [ ] On a SS6 project WITH push enabled (or a fixture toggling those `SiteConfig` fields on), confirm the `Root.SocialMedia` tab still shows the `Last Posted To Social Media` (readonly) and `Update Mode` dropdown as before.
- [ ] Verify the publication ID fields (`PublicationFBUpdateID`, `PublicationTweetID`) are not surfaced anywhere — they remain internal storage only.